### PR TITLE
#18: Add Tournament page with match cards, standings, and predictions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -39,6 +39,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -256,6 +257,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1231,6 +1233,7 @@
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1241,6 +1244,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1401,6 +1405,7 @@
       "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.1",
         "@typescript-eslint/types": "8.57.1",
@@ -8142,6 +8147,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8383,6 +8389,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8535,6 +8542,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -12631,6 +12639,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12640,6 +12649,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -13085,6 +13095,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13151,6 +13162,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13197,6 +13209,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },
@@ -13581,6 +13594,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -14492,6 +14506,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14577,6 +14592,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/app/router/AppRouter.tsx
+++ b/frontend/src/app/router/AppRouter.tsx
@@ -3,6 +3,7 @@ import { Route, Routes } from 'react-router-dom';
 import { MainLayout } from '../../components/layout/MainLayout';
 import HomePage from '../../pages/HomePage/HomePage';
 import PredictionsPage from '../../pages/PredictionsPage/PredictionsPage';
+import TournamentPage from '../../pages/TournamentPage/TournamentPage';
 
 export function AppRouter() {
   return (
@@ -10,6 +11,7 @@ export function AppRouter() {
       <Route element={<MainLayout />}>
         <Route path="/" element={<HomePage />} />
         <Route path="/Predictions" element={<PredictionsPage />} />
+        <Route path="/Tournaments" element={<TournamentPage />} />
       </Route>
     </Routes>
   );

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -27,6 +27,16 @@ export function MainLayout() {
             >
               Predictions
             </NavLink>
+
+            <NavLink
+              to="/Tournaments"
+              className={({ isActive }) =>
+                `nav-link ${isActive ? 'nav-link-active' : 'nav-link-default'}`
+              }
+            >
+              Tournaments
+            </NavLink>
+          
           </nav>
         </div>
       </header>

--- a/frontend/src/pages/TournamentPage/Components/BentoBoxes.tsx
+++ b/frontend/src/pages/TournamentPage/Components/BentoBoxes.tsx
@@ -1,0 +1,24 @@
+function BentoBoxes() {
+    return (
+        <div className="grid grid-cols-2 gap-4">
+            <div className="bg-orange-500 text-white p-4 rounded-2xl flex flex-col justify-between aspect-square">
+                <span className="text-3xl">🏆</span>
+                <div>
+                    <p className="text-[10px] font-bold uppercase opacity-80">Top Scorer</p>
+                    <p className="text-lg font-black leading-tight">Mbappé</p>
+                    <p className="text-xs">5 Goals</p>
+                </div>
+            </div>
+            <div className="bg-blue-100 text-slate-800 p-4 rounded-2xl flex flex-col justify-between aspect-square">
+                <span className="text-3xl">📈</span>
+                <div>
+                    <p className="text-[10px] font-bold uppercase opacity-80">My Rank</p>
+                    <p className="text-lg font-black leading-tight">#1,402</p>
+                    <p className="text-xs text-green-700 font-bold">Top 5%</p>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default BentoBoxes;

--- a/frontend/src/pages/TournamentPage/Components/HeroBanner.tsx
+++ b/frontend/src/pages/TournamentPage/Components/HeroBanner.tsx
@@ -1,0 +1,25 @@
+function HeroBanner() {
+    return (
+        <section className="relative h-48 sm:h-64 rounded-xl overflow-hidden mb-8 shadow-2xl">
+            <div className="absolute inset-0 bg-gradient-to-r from-green-900 to-green-600" />
+            <div className="relative z-10 h-full flex flex-col justify-center px-8">
+                <span className="text-green-300 font-bold tracking-widest text-xs uppercase mb-2">
+                    Summer 2024 Series
+                </span>
+                <h1 className="text-white text-4xl sm:text-6xl font-black tracking-tighter leading-none mb-4">
+                    EURO CHAMPIONS CUP
+                </h1>
+                <div className="flex gap-3 flex-wrap">
+                    <span className="bg-white/20 backdrop-blur-md text-white px-3 py-1 rounded-full text-sm font-medium">
+                        Group Stage Phase
+                    </span>
+                    <span className="bg-orange-500 text-white px-3 py-1 rounded-full text-sm font-bold">
+                        128 Matches Live
+                    </span>
+                </div>
+            </div>
+        </section>
+    );
+}
+
+export default HeroBanner;

--- a/frontend/src/pages/TournamentPage/Components/HeroBanner.tsx
+++ b/frontend/src/pages/TournamentPage/Components/HeroBanner.tsx
@@ -1,20 +1,27 @@
-function HeroBanner() {
+type HeroBannerProps = {
+    season: string;
+    name: string;
+    phase: string;
+    liveMatchCount: number;
+};
+
+function HeroBanner({ season, name, phase, liveMatchCount }: HeroBannerProps) {
     return (
         <section className="relative h-48 sm:h-64 rounded-xl overflow-hidden mb-8 shadow-2xl">
             <div className="absolute inset-0 bg-gradient-to-r from-green-900 to-green-600" />
             <div className="relative z-10 h-full flex flex-col justify-center px-8">
                 <span className="text-green-300 font-bold tracking-widest text-xs uppercase mb-2">
-                    Summer 2024 Series
+                    {season}
                 </span>
                 <h1 className="text-white text-4xl sm:text-6xl font-black tracking-tighter leading-none mb-4">
-                    EURO CHAMPIONS CUP
+                    {name}
                 </h1>
                 <div className="flex gap-3 flex-wrap">
                     <span className="bg-white/20 backdrop-blur-md text-white px-3 py-1 rounded-full text-sm font-medium">
-                        Group Stage Phase
+                        {phase}
                     </span>
                     <span className="bg-orange-500 text-white px-3 py-1 rounded-full text-sm font-bold">
-                        128 Matches Live
+                        {liveMatchCount} Matches Live
                     </span>
                 </div>
             </div>

--- a/frontend/src/pages/TournamentPage/Components/MatchCard.css
+++ b/frontend/src/pages/TournamentPage/Components/MatchCard.css
@@ -1,0 +1,27 @@
+.winnerBtnBase {
+    flex: 1;
+    padding-top: 0.25rem;
+    padding-bottom: 0.25rem;
+    border-radius: 0.5rem;
+    font-size: 0.75rem;
+    line-height: 1rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    transition: all 0.15s ease-in-out;
+}
+
+.winnerBtnActive {
+    background-color: rgb(21 128 61);
+    color: white;
+    box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+}
+
+.winnerBtnInactive {
+    background-color: white;
+    color: rgb(148 163 184);
+}
+
+.winnerBtnInactive:hover {
+    background-color: rgb(241 245 249);
+}

--- a/frontend/src/pages/TournamentPage/Components/MatchCard.tsx
+++ b/frontend/src/pages/TournamentPage/Components/MatchCard.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
+
 import TimeBadgeFunction from './TimeBadge';
 import WinnerButton from './WinnerButton';
-import type { WinningTeam, Prediction, Match } from '../TournamentConstants';
 import { getTeamLabel } from '../TournamentConstants';
+import type { WinningTeam, Prediction, Match } from '../TournamentConstants';
 
 function deriveWinner(home: number, away: number): WinningTeam {
     if (home > away) return 'Home';

--- a/frontend/src/pages/TournamentPage/Components/MatchCard.tsx
+++ b/frontend/src/pages/TournamentPage/Components/MatchCard.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import TimeBadgeFunction from './TimeBadge';
 import WinnerButton from './WinnerButton';
 import type { WinningTeam, Prediction, Match } from '../TournamentConstants';
+import { getTeamLabel } from '../TournamentConstants';
 
 function deriveWinner(home: number, away: number): WinningTeam {
     if (home > away) return 'Home';
@@ -9,13 +10,15 @@ function deriveWinner(home: number, away: number): WinningTeam {
     return 'Draw';
 }
 
+const DEFAULT_PREDICTION: Prediction = { home: 0, away: 0, winningTeam: 'Draw', saved: false };
+
 function MatchCard({
     match,
-    prediction,
+    prediction = DEFAULT_PREDICTION,
     onPredict,
 }: {
     match: Match;
-    prediction: Prediction;
+    prediction?: Prediction;
     onPredict: (id: number, home: number, away: number, winningTeam: WinningTeam) => void;
 }) {
     const [home, setHome] = useState(prediction.home);
@@ -40,13 +43,13 @@ function MatchCard({
             <div className="flex-1 flex flex-col items-center sm:items-end gap-2 text-center sm:text-right">
                 <span className="text-5xl">{match.homeTeam.flag}</span>
                 <div>
-                    <p className="text-xs font-bold uppercase tracking-widest text-slate-400 mb-1">{match.homeTeam.label}</p>
+                    <p className="text-xs font-bold uppercase tracking-widest text-slate-400 mb-1">{getTeamLabel(match.homeTeam.name, match.homeTeam.isHost)}</p>
                     <h3 className="text-xl font-black tracking-tight">{match.homeTeam.name}</h3>
                 </div>
             </div>
 
             {/* Score inputs and winner selector */}
-            <div className="flex flex-col items-center gap-4 bg-slate-50 rounded-2xl p-4 min-w-[200px]">
+            <div className="flex flex-col items-center gap-4 bg-slate-50 rounded-2xl p-4 min-w-[50px]">
                 {/* {Score} */}
                 <div className="flex items-center gap-4">
                     <input
@@ -104,7 +107,7 @@ function MatchCard({
             <div className="flex-1 flex flex-col items-center sm:items-start gap-2 text-center sm:text-left">
                 <span className="text-5xl">{match.awayTeam.flag}</span>
                 <div>
-                    <p className="text-xs font-bold uppercase tracking-widest text-slate-400 mb-1">{match.awayTeam.label}</p>
+                    <p className="text-xs font-bold uppercase tracking-widest text-slate-400 mb-1">{getTeamLabel(match.awayTeam.name)}</p>
                     <h3 className="text-xl font-black tracking-tight">{match.awayTeam.name}</h3>
                 </div>
             </div>

--- a/frontend/src/pages/TournamentPage/Components/MatchCard.tsx
+++ b/frontend/src/pages/TournamentPage/Components/MatchCard.tsx
@@ -1,0 +1,118 @@
+import { useState } from 'react';
+import TimeBadgeFunction from './TimeBadge';
+import WinnerButton from './WinnerButton';
+import type { WinningTeam, Prediction, Match } from '../TournamentConstants';
+
+function deriveWinner(home: number, away: number): WinningTeam {
+    if (home > away) return 'Home';
+    if (home < away) return 'Away';
+    return 'Draw';
+}
+
+function MatchCard({
+    match,
+    prediction,
+    onPredict,
+}: {
+    match: Match;
+    prediction: Prediction;
+    onPredict: (id: number, home: number, away: number, winningTeam: WinningTeam) => void;
+}) {
+    const [home, setHome] = useState(prediction.home);
+    const [away, setAway] = useState(prediction.away);
+    const [winningTeam, setWinningTeam] = useState<WinningTeam>(deriveWinner(prediction.home, prediction.away));
+
+    function handleHomeChange(val: number) {
+        setHome(val);
+        setWinningTeam(deriveWinner(val, away));
+    }
+
+    function handleAwayChange(val: number) {
+        setAway(val);
+        setWinningTeam(deriveWinner(home, val));
+    }
+
+    return (
+        <div className="relative overflow-hidden rounded-xl bg-white p-6 shadow-sm group flex flex-col sm:flex-row items-center gap-8">
+            <div className="absolute top-0 left-0 w-1 h-full bg-green-700 opacity-0 group-hover:opacity-100 transition-opacity" />
+
+            {/* Home team */}
+            <div className="flex-1 flex flex-col items-center sm:items-end gap-2 text-center sm:text-right">
+                <span className="text-5xl">{match.homeTeam.flag}</span>
+                <div>
+                    <p className="text-xs font-bold uppercase tracking-widest text-slate-400 mb-1">{match.homeTeam.label}</p>
+                    <h3 className="text-xl font-black tracking-tight">{match.homeTeam.name}</h3>
+                </div>
+            </div>
+
+            {/* Score inputs and winner selector */}
+            <div className="flex flex-col items-center gap-4 bg-slate-50 rounded-2xl p-4 min-w-[200px]">
+                {/* {Score} */}
+                <div className="flex items-center gap-4">
+                    <input
+                        className="w-14 h-14 bg-white rounded-xl text-center text-2xl font-black border border-slate-200 focus:outline-none focus:ring-2 focus:ring-green-400"
+                        type="number"
+                        min={0}
+                        value={home}
+                        onChange={(e) => handleHomeChange(Number(e.target.value))}
+                    />
+                    <span className="text-slate-400 font-bold">VS</span>
+                    <input
+                        className="w-14 h-14 bg-white rounded-xl text-center text-2xl font-black border border-slate-200 focus:outline-none focus:ring-2 focus:ring-green-400"
+                        type="number"
+                        min={0}
+                        value={away}
+                        onChange={(e) => handleAwayChange(Number(e.target.value))}
+                    />
+                </div>
+
+                {/* Winner selector */}
+                <div className="flex w-full gap-10">
+                    <WinnerButton
+                        isActive={winningTeam === 'Home'}
+                        onClick={() => setWinningTeam('Home')}
+                    >
+                        {match.homeTeam.name}
+                    </WinnerButton>
+                    <WinnerButton
+                        isActive={winningTeam === 'Draw'}
+                        onClick={() => setWinningTeam('Draw')}
+                    >
+                        Draw
+                    </WinnerButton>
+                    <WinnerButton
+                        isActive={winningTeam === 'Away'}
+                        onClick={() => setWinningTeam('Away')}
+                    >
+                        {match.awayTeam.name}
+                    </WinnerButton>
+                </div>
+
+                {/* Submit */}
+                <button
+                    onClick={() => onPredict(match.id, home, away, winningTeam)}
+                    className={`w-full px-6 py-2 rounded-full font-bold text-xs uppercase tracking-widest transition-transform active:scale-95 ${prediction.saved
+                        ? 'bg-green-700 text-white'
+                        : 'bg-orange-600 text-white hover:bg-orange-700'
+                        }`}
+                >
+                    {prediction.saved ? '✓ Saved' : 'Predict Now'}
+                </button>
+            </div>
+
+            {/* Away team */}
+            <div className="flex-1 flex flex-col items-center sm:items-start gap-2 text-center sm:text-left">
+                <span className="text-5xl">{match.awayTeam.flag}</span>
+                <div>
+                    <p className="text-xs font-bold uppercase tracking-widest text-slate-400 mb-1">{match.awayTeam.label}</p>
+                    <h3 className="text-xl font-black tracking-tight">{match.awayTeam.name}</h3>
+                </div>
+            </div>
+
+            <TimeBadgeFunction time={match.time} timeStyle={match.timeStyle} />
+
+        </div>
+    );
+}
+
+export default MatchCard;

--- a/frontend/src/pages/TournamentPage/Components/StandingsTable.tsx
+++ b/frontend/src/pages/TournamentPage/Components/StandingsTable.tsx
@@ -1,39 +1,47 @@
 import { standings } from '../TournamentConstants';
 
+const groups = Array.from(new Set(standings.map((t) => t.group)));
+
 function StandingsTable() {
     return (
-        <div className="bg-slate-50 rounded-2xl p-6">
-            <h3 className="text-xl font-black mb-6 uppercase tracking-tight">Group A Standings</h3>
-            <div className="space-y-3">
-                {standings.map((team) => (
-                    <div
-                        key={team.rank}
-                        className={`p-4 rounded-xl flex items-center justify-between ${team.active
-                            ? 'bg-green-200 text-green-900 shadow-md'
-                            : team.danger
-                                ? 'bg-white border-l-4 border-red-300'
-                                : 'bg-white'
-                            }`}
-                    >
-                        <div className="flex items-center gap-3">
-                            <span className={`font-black text-lg ${!team.active ? 'text-slate-400' : ''}`}>
-                                {team.rank}
-                            </span>
-                            <span className="text-2xl">{team.flag}</span>
-                            <span className="font-bold">{team.name}</span>
-                        </div>
-                        <div className="flex gap-4 items-center">
-                            <span className="text-slate-400 text-sm">{team.pts}pts</span>
-                            <span className={`font-black text-sm ${team.danger ? 'text-red-600' : ''}`}>
-                                {team.gd}
-                            </span>
-                        </div>
+        <div className="space-y-6">
+            {groups.map((group) => (
+                <div key={group} className="bg-slate-50 rounded-2xl p-6">
+                    <h3 className="text-xl font-black mb-4 uppercase tracking-tight">
+                        Group {group}
+                    </h3>
+                    <div className="space-y-3">
+                        {standings
+                            .filter((t) => t.group === group)
+                            .map((team) => (
+                                <div
+                                    key={team.name}
+                                    className={`p-4 rounded-xl flex items-center justify-between ${
+                                        team.rank === 1
+                                            ? 'bg-green-200 text-green-900 shadow-md'
+                                            : team.danger
+                                            ? 'bg-white border-l-4 border-red-300'
+                                            : 'bg-white'
+                                    }`}
+                                >
+                                    <div className="flex items-center gap-3">
+                                        <span className={`font-black text-lg ${team.rank !== 1 ? 'text-slate-400' : ''}`}>
+                                            {team.rank}
+                                        </span>
+                                        <span className="text-2xl">{team.flag}</span>
+                                        <span className="font-bold">{team.name}</span>
+                                    </div>
+                                    <div className="flex gap-4 items-center">
+                                        <span className="text-slate-400 text-sm">{team.pts}pts</span>
+                                        <span className={`font-black text-sm ${team.danger ? 'text-red-600' : ''}`}>
+                                            {team.gd}
+                                        </span>
+                                    </div>
+                                </div>
+                            ))}
                     </div>
-                ))}
-            </div>
-            <button className="w-full mt-6 text-green-700 font-bold text-sm uppercase tracking-widest py-2 hover:bg-white rounded-lg transition-colors">
-                View Detailed Table
-            </button>
+                </div>
+            ))}
         </div>
     );
 }

--- a/frontend/src/pages/TournamentPage/Components/StandingsTable.tsx
+++ b/frontend/src/pages/TournamentPage/Components/StandingsTable.tsx
@@ -1,0 +1,41 @@
+import { standings } from '../TournamentConstants';
+
+function StandingsTable() {
+    return (
+        <div className="bg-slate-50 rounded-2xl p-6">
+            <h3 className="text-xl font-black mb-6 uppercase tracking-tight">Group A Standings</h3>
+            <div className="space-y-3">
+                {standings.map((team) => (
+                    <div
+                        key={team.rank}
+                        className={`p-4 rounded-xl flex items-center justify-between ${team.active
+                            ? 'bg-green-200 text-green-900 shadow-md'
+                            : team.danger
+                                ? 'bg-white border-l-4 border-red-300'
+                                : 'bg-white'
+                            }`}
+                    >
+                        <div className="flex items-center gap-3">
+                            <span className={`font-black text-lg ${!team.active ? 'text-slate-400' : ''}`}>
+                                {team.rank}
+                            </span>
+                            <span className="text-2xl">{team.flag}</span>
+                            <span className="font-bold">{team.name}</span>
+                        </div>
+                        <div className="flex gap-4 items-center">
+                            <span className="text-slate-400 text-sm">{team.pts}pts</span>
+                            <span className={`font-black text-sm ${team.danger ? 'text-red-600' : ''}`}>
+                                {team.gd}
+                            </span>
+                        </div>
+                    </div>
+                ))}
+            </div>
+            <button className="w-full mt-6 text-green-700 font-bold text-sm uppercase tracking-widest py-2 hover:bg-white rounded-lg transition-colors">
+                View Detailed Table
+            </button>
+        </div>
+    );
+}
+
+export default StandingsTable;

--- a/frontend/src/pages/TournamentPage/Components/Tabs.tsx
+++ b/frontend/src/pages/TournamentPage/Components/Tabs.tsx
@@ -1,0 +1,26 @@
+function Tabs({ activeTab, setActiveTab }: { activeTab: 'matches' | 'standings'; setActiveTab: (tab: 'matches' | 'standings') => void }) {
+    return (
+        <div className="flex gap-2 mb-8 bg-slate-100 p-1.5 rounded-full w-fit mx-auto sm:mx-0">
+            <button
+                onClick={() => setActiveTab('matches')}
+                className={`px-8 py-2.5 rounded-full font-bold text-sm transition-all ${activeTab === 'matches'
+                    ? 'bg-green-700 text-white shadow-lg'
+                    : 'text-slate-500 hover:bg-slate-200'
+                    }`}
+            >
+                Matches
+            </button>
+            <button
+                onClick={() => setActiveTab('standings')}
+                className={`px-8 py-2.5 rounded-full font-bold text-sm transition-all ${activeTab === 'standings'
+                    ? 'bg-green-700 text-white shadow-lg'
+                    : 'text-slate-500 hover:bg-slate-200'
+                    }`}
+            >
+                Standings
+            </button>
+        </div>
+    );
+}
+
+export default Tabs;

--- a/frontend/src/pages/TournamentPage/Components/TimeBadge.tsx
+++ b/frontend/src/pages/TournamentPage/Components/TimeBadge.tsx
@@ -1,0 +1,13 @@
+function TimeBadgeFunction(Match: any) {
+    return (
+              <div
+        className={`absolute top-4 right-4 text-[10px] font-bold px-2 py-0.5 rounded ${
+          Match.timeStyle === 'urgent' ? 'text-red-700 bg-red-100' : 'text-slate-500 bg-slate-100'
+        }`}
+      >
+        {Match.time}
+      </div>
+    )
+}
+
+export default TimeBadgeFunction

--- a/frontend/src/pages/TournamentPage/Components/WinnerButton.tsx
+++ b/frontend/src/pages/TournamentPage/Components/WinnerButton.tsx
@@ -1,0 +1,14 @@
+import './MatchCard.css';
+
+function WinnerButton({ isActive, onClick, children }: { isActive: boolean; onClick: () => void; children: React.ReactNode }) {
+    return (
+        <button
+            onClick={onClick}
+            className={`winnerBtnBase ${isActive ? 'winnerBtnActive' : 'winnerBtnInactive'}`}
+        >
+            {children}
+        </button>
+    );
+}
+
+export default WinnerButton;

--- a/frontend/src/pages/TournamentPage/TournamentConstants.ts
+++ b/frontend/src/pages/TournamentPage/TournamentConstants.ts
@@ -5,23 +5,78 @@ export type Match = typeof matches[0];
 export const matches = [
     {
         id: 1,
-        homeTeam: { name: 'GERMANY', flag: '🇩🇪', label: 'Host' },
-        awayTeam: { name: 'FRANCE', flag: '🇫🇷', label: 'Rank 1' },
+        group: 'A',
+        homeTeam: { name: 'GERMANY', flag: '🇩🇪', isHost: true },
+        awayTeam: { name: 'FRANCE', flag: '🇫🇷' },
+        datetime: '2026-04-02T22:00',
         time: '22:00 CET',
         timeStyle: 'urgent',
     },
     {
         id: 2,
-        homeTeam: { name: 'ENGLAND', flag: '🏴󠁧󠁢󠁥󠁮󠁧󠁿', label: 'Seed 4' },
-        awayTeam: { name: 'SPAIN', flag: '🇪🇸', label: 'Seed 2' },
-        time: 'TOMORROW',
+        group: 'B',
+        homeTeam: { name: 'ENGLAND', flag: '🏴󠁧󠁢󠁥󠁮󠁧󠁿' },
+        awayTeam: { name: 'SPAIN', flag: '🇪🇸' },
+        datetime: '2026-04-03T18:00',
+        time: 'TOMORROW 18:00',
+        timeStyle: 'default',
+    },
+    {
+        id: 3,
+        group: 'A',
+        homeTeam: { name: 'PORTUGAL', flag: '🇵🇹' },
+        awayTeam: { name: 'NETHERLANDS', flag: '🇳🇱' },
+        datetime: '2026-04-02T19:00',
+        time: '19:00 CET',
+        timeStyle: 'urgent',
+    },
+    {
+        id: 4,
+        group: 'B',
+        homeTeam: { name: 'ITALY', flag: '🇮🇹' },
+        awayTeam: { name: 'CROATIA', flag: '🇭🇷' },
+        datetime: '2026-04-04T20:00',
+        time: 'IN 2 DAYS',
+        timeStyle: 'default',
+    },
+    {
+        id: 5,
+        group: 'C',
+        homeTeam: { name: 'BELGIUM', flag: '🇧🇪' },
+        awayTeam: { name: 'AUSTRIA', flag: '🇦🇹' },
+        datetime: '2026-04-05T15:00',
+        time: 'IN 3 DAYS',
+        timeStyle: 'default',
+    },
+    {
+        id: 6,
+        group: 'C',
+        homeTeam: { name: 'DENMARK', flag: '🇩🇰' },
+        awayTeam: { name: 'TURKIYE', flag: '🇹🇷' },
+        datetime: '2026-04-05T18:00',
+        time: 'IN 3 DAYS',
         timeStyle: 'default',
     },
 ];
 
+export function getTeamLabel(teamName: string, isHost?: boolean): string {
+    if (isHost) return 'Host';
+    const team = standings.find((t) => t.name.toUpperCase() === teamName);
+    if (!team) return '';
+    return `Group ${team.group} · Rank ${team.rank}`;
+}
+
 export const standings = [
-    { rank: 1, name: 'Germany', flag: '🇩🇪', pts: 9, gd: '+7', active: true, danger: false },
-    { rank: 2, name: 'Switzerland', flag: '🇨🇭', pts: 5, gd: '+1', active: false, danger: false },
-    { rank: 3, name: 'Hungary', flag: '🇭🇺', pts: 3, gd: '-2', active: false, danger: false },
-    { rank: 4, name: 'Scotland', flag: '🏴󠁧󠁢󠁳󠁣󠁴󠁿', pts: 0, gd: '-6', active: false, danger: true },
+    { group: 'A', rank: 1, name: 'Germany',     flag: '🇩🇪', pts: 9, gd: '+7', danger: false },
+    { group: 'A', rank: 2, name: 'Switzerland', flag: '🇨🇭', pts: 5, gd: '+1', danger: false },
+    { group: 'A', rank: 3, name: 'Hungary',     flag: '🇭🇺', pts: 3, gd: '-2', danger: false },
+    { group: 'A', rank: 4, name: 'Scotland',    flag: '🏴󠁧󠁢󠁳󠁣󠁴󠁿', pts: 0, gd: '-6', danger: true  },
+    { group: 'B', rank: 1, name: 'Spain',       flag: '🇪🇸', pts: 7, gd: '+5', danger: false },
+    { group: 'B', rank: 2, name: 'Croatia',     flag: '🇭🇷', pts: 4, gd: '+0', danger: false },
+    { group: 'B', rank: 3, name: 'Italy',       flag: '🇮🇹', pts: 4, gd: '-1', danger: false },
+    { group: 'B', rank: 4, name: 'Albania',     flag: '🇦🇱', pts: 1, gd: '-4', danger: true  },
+    { group: 'C', rank: 1, name: 'England',     flag: '🏴󠁧󠁢󠁥󠁮󠁧󠁿', pts: 6, gd: '+4', danger: false },
+    { group: 'C', rank: 2, name: 'Denmark',     flag: '🇩🇰', pts: 5, gd: '+2', danger: false },
+    { group: 'C', rank: 3, name: 'Slovenia',    flag: '🇸🇮', pts: 2, gd: '-1', danger: false },
+    { group: 'C', rank: 4, name: 'Serbia',      flag: '🇷🇸', pts: 1, gd: '-5', danger: true  },
 ];

--- a/frontend/src/pages/TournamentPage/TournamentConstants.ts
+++ b/frontend/src/pages/TournamentPage/TournamentConstants.ts
@@ -1,0 +1,27 @@
+export type WinningTeam = 'Home' | 'Draw' | 'Away';
+export type Prediction = { home: number; away: number; winningTeam: WinningTeam; saved: boolean };
+export type Match = typeof matches[0];
+
+export const matches = [
+    {
+        id: 1,
+        homeTeam: { name: 'GERMANY', flag: '🇩🇪', label: 'Host' },
+        awayTeam: { name: 'FRANCE', flag: '🇫🇷', label: 'Rank 1' },
+        time: '22:00 CET',
+        timeStyle: 'urgent',
+    },
+    {
+        id: 2,
+        homeTeam: { name: 'ENGLAND', flag: '🏴󠁧󠁢󠁥󠁮󠁧󠁿', label: 'Seed 4' },
+        awayTeam: { name: 'SPAIN', flag: '🇪🇸', label: 'Seed 2' },
+        time: 'TOMORROW',
+        timeStyle: 'default',
+    },
+];
+
+export const standings = [
+    { rank: 1, name: 'Germany', flag: '🇩🇪', pts: 9, gd: '+7', active: true, danger: false },
+    { rank: 2, name: 'Switzerland', flag: '🇨🇭', pts: 5, gd: '+1', active: false, danger: false },
+    { rank: 3, name: 'Hungary', flag: '🇭🇺', pts: 3, gd: '-2', active: false, danger: false },
+    { rank: 4, name: 'Scotland', flag: '🏴󠁧󠁢󠁳󠁣󠁴󠁿', pts: 0, gd: '-6', active: false, danger: true },
+];

--- a/frontend/src/pages/TournamentPage/TournamentPage.tsx
+++ b/frontend/src/pages/TournamentPage/TournamentPage.tsx
@@ -1,11 +1,61 @@
-function TournamentPage()
-{
+import { useState } from 'react';
+import { matches } from './TournamentConstants';
+import type { Prediction, WinningTeam } from './TournamentConstants';
+import HeroBanner from './Components/HeroBanner';
+import Tabs from './Components/Tabs';
+import MatchCard from './Components/MatchCard';
+import StandingsTable from './Components/StandingsTable';
+import BentoBoxes from './Components/BentoBoxes';
+
+function TournamentPage() {
+    const [activeTab, setActiveTab] = useState<'matches' | 'standings'>('matches');
+    const [predictions, setPredictions] = useState<Record<number, Prediction>>({
+        1: { home: 0, away: 0, winningTeam: 'Draw', saved: false },
+        2: { home: 1, away: 2, winningTeam: 'Away', saved: false },
+    });
+
+    function handlePredict(id: number, home: number, away: number, winningTeam: WinningTeam) {
+        setPredictions((prev) => ({ ...prev, [id]: { home, away, saved: true, winningTeam } }));
+    }
+
     return (
-        <div className="p-6">
-            <h1 className="text-3xl font-bold">Tournaments</h1>
-            <p className="mt-2 text-gray-500">Here you can find all the upcoming tournaments.</p>
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 py-8">
+            <HeroBanner />
+
+            <Tabs activeTab={activeTab} setActiveTab={setActiveTab} />
+
+            <div className="grid grid-cols-1 laptop:grid-cols-12 gap-8">
+                {/* Match list */}
+                <div className="laptop:col-span-8 space-y-6">
+                    <div className="flex items-center justify-between">
+                        <h2 className="text-2xl font-black text-slate-900">
+                            ROUND OF 16{' '}
+                            <span className="text-slate-400 font-normal ml-2">Upcoming</span>
+                        </h2>
+                        <span className="text-green-700 font-bold text-sm cursor-pointer hover:underline">
+                            View Calendar
+                        </span>
+                    </div>
+
+                    {matches.map((match) => (
+                        <MatchCard
+                            key={match.id}
+                            match={match}
+                            prediction={predictions[match.id]}
+                            onPredict={handlePredict}
+                        />
+                    ))}
+                </div>
+
+                {/* Sidebar */}
+                <div className="laptop:col-span-4 space-y-6">
+                    <StandingsTable />
+
+                    <BentoBoxes />
+                </div>
+            </div>
         </div>
-    )
+    );
 }
 
-export default TournamentPage
+export default TournamentPage;

--- a/frontend/src/pages/TournamentPage/TournamentPage.tsx
+++ b/frontend/src/pages/TournamentPage/TournamentPage.tsx
@@ -1,0 +1,11 @@
+function TournamentPage()
+{
+    return (
+        <div className="p-6">
+            <h1 className="text-3xl font-bold">Tournaments</h1>
+            <p className="mt-2 text-gray-500">Here you can find all the upcoming tournaments.</p>
+        </div>
+    )
+}
+
+export default TournamentPage

--- a/frontend/src/pages/TournamentPage/TournamentPage.tsx
+++ b/frontend/src/pages/TournamentPage/TournamentPage.tsx
@@ -1,6 +1,14 @@
 import { useState } from 'react';
 import { matches } from './TournamentConstants';
 import type { Prediction, WinningTeam } from './TournamentConstants';
+
+const groups = Array.from(new Set(matches.map((m) => m.group)));
+const matchesByGroup = groups.map((group) => ({
+    group,
+    matches: matches
+        .filter((m) => m.group === group)
+        .sort((a, b) => a.datetime.localeCompare(b.datetime)),
+}));
 import HeroBanner from './Components/HeroBanner';
 import Tabs from './Components/Tabs';
 import MatchCard from './Components/MatchCard';
@@ -20,40 +28,56 @@ function TournamentPage() {
 
     return (
         <div className="max-w-7xl mx-auto px-4 sm:px-6 py-8">
-            <HeroBanner />
+            <HeroBanner
+                season="Summer 2024 Series"
+                name="EURO CHAMPIONS CUP"
+                phase="Group Stage Phase"
+                liveMatchCount={128}
+            />
 
             <Tabs activeTab={activeTab} setActiveTab={setActiveTab} />
 
-            <div className="grid grid-cols-1 laptop:grid-cols-12 gap-8">
-                {/* Match list */}
-                <div className="laptop:col-span-8 space-y-6">
-                    <div className="flex items-center justify-between">
-                        <h2 className="text-2xl font-black text-slate-900">
-                            ROUND OF 16{' '}
-                            <span className="text-slate-400 font-normal ml-2">Upcoming</span>
-                        </h2>
-                        <span className="text-green-700 font-bold text-sm cursor-pointer hover:underline">
-                            View Calendar
-                        </span>
+            {activeTab === 'matches' && (
+                <div className="grid grid-cols-1 laptop:grid-cols-12 gap-8">
+                    {/* Match list */}
+                    <div className="laptop:col-span-8 space-y-6">
+                        <div className="flex items-center justify-between">
+                            <h2 className="text-2xl font-black text-slate-900">
+                                ROUND OF 16{' '}
+                                <span className="text-slate-400 font-normal ml-2">Upcoming</span>
+                            </h2>
+                            <span className="text-green-700 font-bold text-sm cursor-pointer hover:underline">
+                                View Calendar
+                            </span>
+                        </div>
+
+                        {matchesByGroup.map(({ group, matches: groupMatches }) => (
+                            <div key={group}>
+                                <h3 className="text-sm font-bold uppercase tracking-widest text-slate-400 mb-3">
+                                    Group {group}
+                                </h3>
+                                <div className="space-y-4">
+                                    {groupMatches.map((match) => (
+                                        <MatchCard
+                                            key={match.id}
+                                            match={match}
+                                            prediction={predictions[match.id]}
+                                            onPredict={handlePredict}
+                                        />
+                                    ))}
+                                </div>
+                            </div>
+                        ))}
                     </div>
 
-                    {matches.map((match) => (
-                        <MatchCard
-                            key={match.id}
-                            match={match}
-                            prediction={predictions[match.id]}
-                            onPredict={handlePredict}
-                        />
-                    ))}
+                    {/* Sidebar */}
+                    <div className="laptop:col-span-4 space-y-6">
+                        <BentoBoxes />
+                    </div>
                 </div>
+            )}
 
-                {/* Sidebar */}
-                <div className="laptop:col-span-4 space-y-6">
-                    <StandingsTable />
-
-                    <BentoBoxes />
-                </div>
-            </div>
+            {activeTab === 'standings' && <StandingsTable />}
         </div>
     );
 }

--- a/frontend/src/pages/TournamentPage/TournamentPage.tsx
+++ b/frontend/src/pages/TournamentPage/TournamentPage.tsx
@@ -1,4 +1,9 @@
 import { useState } from 'react';
+
+import HeroBanner from './Components/HeroBanner';
+import MatchCard from './Components/MatchCard';
+import StandingsTable from './Components/StandingsTable';
+import Tabs from './Components/Tabs';
 import { matches } from './TournamentConstants';
 import type { Prediction, WinningTeam } from './TournamentConstants';
 
@@ -9,11 +14,8 @@ const matchesByGroup = groups.map((group) => ({
         .filter((m) => m.group === group)
         .sort((a, b) => a.datetime.localeCompare(b.datetime)),
 }));
-import HeroBanner from './Components/HeroBanner';
-import Tabs from './Components/Tabs';
-import MatchCard from './Components/MatchCard';
-import StandingsTable from './Components/StandingsTable';
-import BentoBoxes from './Components/BentoBoxes';
+
+
 
 function TournamentPage() {
     const [activeTab, setActiveTab] = useState<'matches' | 'standings'>('matches');
@@ -72,7 +74,7 @@ function TournamentPage() {
 
                     {/* Sidebar */}
                     <div className="laptop:col-span-4 space-y-6">
-                        <BentoBoxes />
+                        {/* <BentoBoxes /> */}
                     </div>
                 </div>
             )}

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -37,3 +37,13 @@ header {
     @apply bg-slate-200 text-slate-900;
   }
 }
+
+input[type=number] ::-webkit-inner-spin-button,
+input[type=number] ::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+input[type=number] {
+  -moz-appearance: textfield;
+}

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -38,8 +38,8 @@ header {
   }
 }
 
-input[type=number] ::-webkit-inner-spin-button,
-input[type=number] ::-webkit-outer-spin-button {
+input[type=number]::-webkit-inner-spin-button,
+input[type=number]::-webkit-outer-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}', './src/**/*.css'],
   theme: {
     extend: {
       screens: {


### PR DESCRIPTION
## Summary
- Adds a Tournament page showing matches grouped by group and sorted by time
- Match cards include score inputs and a winner selector (Home / Draw / Away)
- Standings table separated by group with rank 1 always highlighted green
- Hero banner, tabs, match cards, standings, and bento boxes split into separate components under `Components/`

## Implementation notes
- All data is currently hardcoded in `TournamentConstants.ts` — backend integration is pending
- Team rank/seed labels are derived from standings data, not manually set
- `HeroBanner` accepts props (season, name, phase, liveMatchCount) and is ready to receive API data
- Predictions are saved to local React state only — POST to `/api/predictions` will be wired up once the backend endpoint exists

## Out of scope / follow-up
- [ ] Backend endpoints: `GET /api/tournaments/{id}/matches`, `GET /api/tournaments/{id}/standings`
- [ ] Replace hardcoded constants with API calls
- [ ] POST predictions to backend
- [ ] Authenticated prediction saving