### PR TITLE
#13: add temp session-based auth, add dummy users, login page

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -50,6 +50,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-crypto</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa-test</artifactId>
 			<scope>test</scope>

--- a/backend/src/main/java/com/predictorama/backend/adapter/persistence/adapter/BCryptPasswordVerifier.java
+++ b/backend/src/main/java/com/predictorama/backend/adapter/persistence/adapter/BCryptPasswordVerifier.java
@@ -1,0 +1,16 @@
+package com.predictorama.backend.adapter.persistence.adapter;
+
+import com.predictorama.backend.domain.port.PasswordVerifier;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BCryptPasswordVerifier implements PasswordVerifier {
+
+    private final BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+
+    @Override
+    public boolean matches(String rawPassword, String encodedPassword) {
+        return encoder.matches(rawPassword, encodedPassword);
+    }
+}

--- a/backend/src/main/java/com/predictorama/backend/adapter/persistence/entity/UserEntity.java
+++ b/backend/src/main/java/com/predictorama/backend/adapter/persistence/entity/UserEntity.java
@@ -29,4 +29,7 @@ public class UserEntity extends BaseEntity{
     @Column(name = "system_role", nullable = false)
     private Role systemRole;
 
+    @Column(name = "password_hash")
+    private String passwordHash;
+
 }

--- a/backend/src/main/java/com/predictorama/backend/adapter/persistence/mapper/UserMapper.java
+++ b/backend/src/main/java/com/predictorama/backend/adapter/persistence/mapper/UserMapper.java
@@ -11,6 +11,7 @@ public class UserMapper {
                 .username(entity.getUsername())
                 .email(entity.getEmail())
                 .systemRole(entity.getSystemRole())
+                .passwordHash(entity.getPasswordHash())
                 .build();
     }
 
@@ -20,6 +21,7 @@ public class UserMapper {
                 .username(user.getUsername())
                 .email(user.getEmail())
                 .systemRole(user.getSystemRole())
+                .passwordHash(user.getPasswordHash())
                 .build();
     }
 }

--- a/backend/src/main/java/com/predictorama/backend/adapter/rest/AuthExceptionHandler.java
+++ b/backend/src/main/java/com/predictorama/backend/adapter/rest/AuthExceptionHandler.java
@@ -1,0 +1,22 @@
+package com.predictorama.backend.adapter.rest;
+
+import com.predictorama.backend.domain.exception.InvalidCredentialsException;
+import com.predictorama.backend.domain.exception.UserNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class AuthExceptionHandler {
+
+    @ExceptionHandler(InvalidCredentialsException.class)
+    public ResponseEntity<Void> handleInvalidCredentials(InvalidCredentialsException ex) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<Void> handleUserNotFound(UserNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+    }
+}

--- a/backend/src/main/java/com/predictorama/backend/adapter/rest/SessionService.java
+++ b/backend/src/main/java/com/predictorama/backend/adapter/rest/SessionService.java
@@ -1,0 +1,25 @@
+package com.predictorama.backend.adapter.rest;
+
+import jakarta.servlet.http.HttpSession;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+public class SessionService {
+
+    private static final String USER_ID_KEY = "userId";
+
+    public void setUserId(HttpSession session, UUID userId) {
+        session.setAttribute(USER_ID_KEY, userId);
+    }
+
+    public Optional<UUID> getUserId(HttpSession session) {
+        return Optional.ofNullable((UUID) session.getAttribute(USER_ID_KEY));
+    }
+
+    public void invalidate(HttpSession session) {
+        session.invalidate();
+    }
+}

--- a/backend/src/main/java/com/predictorama/backend/adapter/rest/controller/AuthController.java
+++ b/backend/src/main/java/com/predictorama/backend/adapter/rest/controller/AuthController.java
@@ -1,0 +1,51 @@
+package com.predictorama.backend.adapter.rest.controller;
+
+import com.predictorama.backend.adapter.rest.SessionService;
+import com.predictorama.backend.adapter.rest.dto.LoginRequest;
+import com.predictorama.backend.adapter.rest.dto.UserResponse;
+import com.predictorama.backend.adapter.rest.mapper.UserRestMapper;
+import com.predictorama.backend.domain.service.AuthService;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private static final Logger log = LoggerFactory.getLogger(AuthController.class);
+
+    private final AuthService authService;
+    private final SessionService sessionService;
+
+    @PostMapping("/login")
+    public UserResponse login(@RequestBody LoginRequest request, HttpSession session) {
+        log.info("POST /api/auth/login - email={}", request.email());
+        var user = authService.login(request.email(), request.password());
+        sessionService.setUserId(session, user.getId());
+        log.info("Login successful - userId={}", user.getId());
+        return UserRestMapper.toResponse(user);
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<UserResponse> me(HttpSession session) {
+        return sessionService.getUserId(session)
+                .map(userId -> {
+                    var user = authService.getById(userId);
+                    return ResponseEntity.ok(UserRestMapper.toResponse(user));
+                })
+                .orElse(ResponseEntity.status(401).build());
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(HttpSession session) {
+        sessionService.invalidate(session);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/predictorama/backend/adapter/rest/dto/LoginRequest.java
+++ b/backend/src/main/java/com/predictorama/backend/adapter/rest/dto/LoginRequest.java
@@ -1,0 +1,3 @@
+package com.predictorama.backend.adapter.rest.dto;
+
+public record LoginRequest(String email, String password) {}

--- a/backend/src/main/java/com/predictorama/backend/config/CorsConfig.java
+++ b/backend/src/main/java/com/predictorama/backend/config/CorsConfig.java
@@ -21,7 +21,8 @@ public class CorsConfig {
                                 System.getenv().getOrDefault("ALLOWED_ORIGIN", "http://localhost:5173")
                         )
                         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-                        .allowedHeaders("*");
+                        .allowedHeaders("*")
+                        .allowCredentials(true);
             }
         };
     }

--- a/backend/src/main/java/com/predictorama/backend/config/DomainConfig.java
+++ b/backend/src/main/java/com/predictorama/backend/config/DomainConfig.java
@@ -1,23 +1,35 @@
 package com.predictorama.backend.config;
 
+import com.predictorama.backend.domain.port.PasswordVerifier;
 import com.predictorama.backend.domain.port.persistence.GroupMemberRepositoryPort;
 import com.predictorama.backend.domain.port.persistence.GroupRepositoryPort;
 import com.predictorama.backend.domain.port.persistence.UserRepositoryPort;
+import com.predictorama.backend.domain.service.AuthService;
 import com.predictorama.backend.domain.service.GroupService;
 import com.predictorama.backend.domain.service.UserService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 @Configuration
 public class DomainConfig {
 
+    // TODO: remove default password once real auth (Google OAuth) is in place
+    private static final String DEFAULT_PASSWORD = "predictorama123";
+
     @Bean
     public UserService userService(UserRepositoryPort userRepository) {
-        return new UserService(userRepository);
+        String defaultPasswordHash = new BCryptPasswordEncoder().encode(DEFAULT_PASSWORD);
+        return new UserService(userRepository, defaultPasswordHash);
     }
 
     @Bean
     public GroupService groupService(GroupRepositoryPort groupRepository, GroupMemberRepositoryPort groupMemberRepository) {
         return new GroupService(groupRepository, groupMemberRepository);
+    }
+
+    @Bean
+    public AuthService authService(UserRepositoryPort userRepository, PasswordVerifier passwordVerifier) {
+        return new AuthService(userRepository, passwordVerifier);
     }
 }

--- a/backend/src/main/java/com/predictorama/backend/domain/entity/User.java
+++ b/backend/src/main/java/com/predictorama/backend/domain/entity/User.java
@@ -14,4 +14,5 @@ public class User {
     private String username;
     private String email;
     private Role systemRole;
+    private String passwordHash;
 }

--- a/backend/src/main/java/com/predictorama/backend/domain/exception/InvalidCredentialsException.java
+++ b/backend/src/main/java/com/predictorama/backend/domain/exception/InvalidCredentialsException.java
@@ -1,0 +1,7 @@
+package com.predictorama.backend.domain.exception;
+
+public class InvalidCredentialsException extends RuntimeException {
+    public InvalidCredentialsException() {
+        super("Invalid credentials");
+    }
+}

--- a/backend/src/main/java/com/predictorama/backend/domain/exception/UserNotFoundException.java
+++ b/backend/src/main/java/com/predictorama/backend/domain/exception/UserNotFoundException.java
@@ -1,0 +1,9 @@
+package com.predictorama.backend.domain.exception;
+
+import java.util.UUID;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(UUID id) {
+        super("User not found: " + id);
+    }
+}

--- a/backend/src/main/java/com/predictorama/backend/domain/port/PasswordVerifier.java
+++ b/backend/src/main/java/com/predictorama/backend/domain/port/PasswordVerifier.java
@@ -1,0 +1,5 @@
+package com.predictorama.backend.domain.port;
+
+public interface PasswordVerifier {
+    boolean matches(String rawPassword, String encodedPassword);
+}

--- a/backend/src/main/java/com/predictorama/backend/domain/service/AuthService.java
+++ b/backend/src/main/java/com/predictorama/backend/domain/service/AuthService.java
@@ -1,0 +1,31 @@
+package com.predictorama.backend.domain.service;
+
+import com.predictorama.backend.domain.entity.User;
+import com.predictorama.backend.domain.exception.InvalidCredentialsException;
+import com.predictorama.backend.domain.exception.UserNotFoundException;
+import com.predictorama.backend.domain.port.PasswordVerifier;
+import com.predictorama.backend.domain.port.persistence.UserRepositoryPort;
+import lombok.RequiredArgsConstructor;
+
+import java.util.UUID;
+
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepositoryPort userRepository;
+    private final PasswordVerifier passwordVerifier;
+
+    public User login(String email, String password) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(InvalidCredentialsException::new);
+        if (user.getPasswordHash() == null || !passwordVerifier.matches(password, user.getPasswordHash())) {
+            throw new InvalidCredentialsException();
+        }
+        return user;
+    }
+
+    public User getById(UUID id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new UserNotFoundException(id));
+    }
+}

--- a/backend/src/main/java/com/predictorama/backend/domain/service/UserService.java
+++ b/backend/src/main/java/com/predictorama/backend/domain/service/UserService.java
@@ -11,9 +11,17 @@ import java.util.UUID;
 public class UserService {
 
     private final UserRepositoryPort userRepository;
+    // TODO: remove default password once real auth (Google OAuth) is in place
+    private final String defaultPasswordHash;
 
     public User createUser(String username, String email) {
-        User user = new User(UUID.randomUUID(), username, email, Role.USER);
+        User user = User.builder()
+                .id(UUID.randomUUID())
+                .username(username)
+                .email(email)
+                .systemRole(Role.USER)
+                .passwordHash(defaultPasswordHash)
+                .build();
         return userRepository.save(user);
     }
 }

--- a/backend/src/main/resources/db/changelog/006-add-password-hash-to-users.yaml
+++ b/backend/src/main/resources/db/changelog/006-add-password-hash-to-users.yaml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: 006-add-password-hash-to-users
+      author: dev
+      changes:
+        - addColumn:
+            tableName: users
+            columns:
+              - column:
+                  name: password_hash
+                  type: varchar(255)
+                  constraints:
+                    nullable: true

--- a/backend/src/main/resources/db/changelog/007-seed-test-users.yaml
+++ b/backend/src/main/resources/db/changelog/007-seed-test-users.yaml
@@ -1,0 +1,56 @@
+databaseChangeLog:
+  - changeSet:
+      id: 007-seed-test-users
+      author: dev
+      context: dev
+      changes:
+        - insert:
+            tableName: users
+            columns:
+              - column: { name: id, value: '00000000-0000-0000-0000-000000000001' }
+              - column: { name: username, value: alice }
+              - column: { name: email, value: alice@test.com }
+              - column: { name: system_role, value: ADMIN }
+              - column: { name: password_hash, value: '$2a$10$GJZJ2XQatQweZwfBRixGg.zSeZS6v/j56UshpHtXuPn4HuDMYBUVe' }
+              - column: { name: created_at, valueDate: 'now()' }
+              - column: { name: updated_at, valueDate: 'now()' }
+        - insert:
+            tableName: users
+            columns:
+              - column: { name: id, value: '00000000-0000-0000-0000-000000000002' }
+              - column: { name: username, value: bob }
+              - column: { name: email, value: bob@test.com }
+              - column: { name: system_role, value: USER }
+              - column: { name: password_hash, value: '$2a$10$GJZJ2XQatQweZwfBRixGg.zSeZS6v/j56UshpHtXuPn4HuDMYBUVe' }
+              - column: { name: created_at, valueDate: 'now()' }
+              - column: { name: updated_at, valueDate: 'now()' }
+        - insert:
+            tableName: users
+            columns:
+              - column: { name: id, value: '00000000-0000-0000-0000-000000000003' }
+              - column: { name: username, value: carol }
+              - column: { name: email, value: carol@test.com }
+              - column: { name: system_role, value: USER }
+              - column: { name: password_hash, value: '$2a$10$GJZJ2XQatQweZwfBRixGg.zSeZS6v/j56UshpHtXuPn4HuDMYBUVe' }
+              - column: { name: created_at, valueDate: 'now()' }
+              - column: { name: updated_at, valueDate: 'now()' }
+        - insert:
+            tableName: users
+            columns:
+              - column: { name: id, value: '00000000-0000-0000-0000-000000000004' }
+              - column: { name: username, value: dave }
+              - column: { name: email, value: dave@test.com }
+              - column: { name: system_role, value: USER }
+              - column: { name: password_hash, value: '$2a$10$GJZJ2XQatQweZwfBRixGg.zSeZS6v/j56UshpHtXuPn4HuDMYBUVe' }
+              - column: { name: created_at, valueDate: 'now()' }
+              - column: { name: updated_at, valueDate: 'now()' }
+        - insert:
+            tableName: users
+            columns:
+              - column: { name: id, value: '00000000-0000-0000-0000-000000000005' }
+              - column: { name: username, value: eve }
+              - column: { name: email, value: eve@test.com }
+              - column: { name: system_role, value: USER }
+              - column: { name: password_hash, value: '$2a$10$GJZJ2XQatQweZwfBRixGg.zSeZS6v/j56UshpHtXuPn4HuDMYBUVe' }
+              - column: { name: created_at, valueDate: 'now()' }
+              - column: { name: updated_at, valueDate: 'now()' }

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -9,3 +9,7 @@ databaseChangeLog:
       file: db/changelog/004-create-core-tables.yaml
   - include:
       file: db/changelog/005-add-team-image-url.yaml
+  - include:
+      file: db/changelog/006-add-password-hash-to-users.yaml
+  - include:
+      file: db/changelog/007-seed-test-users.yaml

--- a/backend/src/test/java/com/predictorama/backend/domain/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/predictorama/backend/domain/service/AuthServiceTest.java
@@ -1,0 +1,132 @@
+package com.predictorama.backend.domain.service;
+
+import com.predictorama.backend.domain.entity.Role;
+import com.predictorama.backend.domain.entity.User;
+import com.predictorama.backend.domain.exception.InvalidCredentialsException;
+import com.predictorama.backend.domain.exception.UserNotFoundException;
+import com.predictorama.backend.domain.port.PasswordVerifier;
+import com.predictorama.backend.domain.port.persistence.UserRepositoryPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AuthServiceTest {
+
+    private AuthService authService;
+    private InMemoryUserRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = new InMemoryUserRepository();
+        authService = new AuthService(userRepository, new FakePasswordVerifier());
+    }
+
+    @Test
+    void login_returnsUser_whenCredentialsAreValid() {
+        var user = userWithHash("alice@test.com", "hashed:password123");
+        userRepository.save(user);
+
+        var result = authService.login("alice@test.com", "password123");
+
+        assertThat(result.getEmail()).isEqualTo("alice@test.com");
+    }
+
+    @Test
+    void login_throws_whenEmailNotFound() {
+        assertThatThrownBy(() -> authService.login("unknown@test.com", "password123"))
+                .isInstanceOf(InvalidCredentialsException.class);
+    }
+
+    @Test
+    void login_throws_whenPasswordDoesNotMatch() {
+        var user = userWithHash("alice@test.com", "hashed:password123");
+        userRepository.save(user);
+
+        assertThatThrownBy(() -> authService.login("alice@test.com", "wrongpassword"))
+                .isInstanceOf(InvalidCredentialsException.class);
+    }
+
+    @Test
+    void login_throws_whenPasswordHashIsNull() {
+        var user = userWithHash("alice@test.com", null);
+        userRepository.save(user);
+
+        assertThatThrownBy(() -> authService.login("alice@test.com", "password123"))
+                .isInstanceOf(InvalidCredentialsException.class);
+    }
+
+    @Test
+    void getById_returnsUser_whenExists() {
+        var user = userWithHash("alice@test.com", "hashed:password123");
+        userRepository.save(user);
+
+        var result = authService.getById(user.getId());
+
+        assertThat(result.getId()).isEqualTo(user.getId());
+    }
+
+    @Test
+    void getById_throws_whenNotFound() {
+        assertThatThrownBy(() -> authService.getById(UUID.randomUUID()))
+                .isInstanceOf(UserNotFoundException.class);
+    }
+
+    // --- Helpers ---
+
+    private User userWithHash(String email, String hash) {
+        return User.builder()
+                .id(UUID.randomUUID())
+                .username(email.split("@")[0])
+                .email(email)
+                .systemRole(Role.USER)
+                .passwordHash(hash)
+                .build();
+    }
+
+    // Fake: interprets encoded as "hashed:<raw>" so tests can control matching
+    static class FakePasswordVerifier implements PasswordVerifier {
+        @Override
+        public boolean matches(String rawPassword, String encodedPassword) {
+            return encodedPassword != null && encodedPassword.equals("hashed:" + rawPassword);
+        }
+    }
+
+    static class InMemoryUserRepository implements UserRepositoryPort {
+        private final Map<UUID, User> store = new HashMap<>();
+
+        @Override
+        public User save(User user) {
+            store.put(user.getId(), user);
+            return user;
+        }
+
+        @Override
+        public Optional<User> findById(UUID id) {
+            return Optional.ofNullable(store.get(id));
+        }
+
+        @Override
+        public Optional<User> findByUsername(String username) {
+            return store.values().stream().filter(u -> u.getUsername().equals(username)).findFirst();
+        }
+
+        @Override
+        public Optional<User> findByEmail(String email) {
+            return store.values().stream().filter(u -> u.getEmail().equals(email)).findFirst();
+        }
+
+        @Override
+        public boolean existsByUsername(String username) {
+            return store.values().stream().anyMatch(u -> u.getUsername().equals(username));
+        }
+
+        @Override
+        public boolean existsByEmail(String email) {
+            return store.values().stream().anyMatch(u -> u.getEmail().equals(email));
+        }
+    }
+}

--- a/backend/src/test/java/com/predictorama/backend/domain/service/UserServiceTest.java
+++ b/backend/src/test/java/com/predictorama/backend/domain/service/UserServiceTest.java
@@ -18,7 +18,7 @@ class UserServiceTest {
     @BeforeEach
     void setUp() {
         userRepository = new InMemoryUserRepository();
-        userService = new UserService(userRepository);
+        userService = new UserService(userRepository, "hashed-default");
     }
 
     @Test

--- a/docs/plans/13-temp-simple-login.md
+++ b/docs/plans/13-temp-simple-login.md
@@ -1,0 +1,507 @@
+# Plan: Temporary Simple Login (Issue #13)
+
+## Context & Goal
+
+The app currently has no authentication. Every page that requires a user assumes a logged-in session, and workarounds like manually pasting UUIDs into form fields are in place. This makes UI development and multi-user testing extremely painful.
+
+The long-term plan is Google OAuth, but that is not yet the priority. This plan implements a **temporary, dev-grade login system** using email + bcrypt password. It is intentionally minimal — no Spring Security, no JWT, no token refresh — just enough to:
+
+- Allow real login with multiple named test users
+- Provide a `currentUser` (with a real UUID) to every frontend page
+- Remove all manual UUID input workarounds
+- Support different roles and user scenarios (e.g. self-referential checks, group ownership)
+
+This solution will coexist with Google OAuth when that is added; the `users` table already exists and the password column can simply remain unused for OAuth users.
+
+---
+
+## Decisions
+
+### No Spring Security
+Spring Security adds significant configuration complexity for a temporary dev feature. Instead, `HttpSession` is used directly — Spring Boot ships session support out of the box with no extra config. The session holds the authenticated `userId`; a `SessionService` retrieves the current user from the session. When real auth is added, this layer is replaced, not refactored.
+
+### BCrypt over plaintext
+Even for dev/test passwords, storing plaintext in a
+migration file is bad practice. BCrypt hashing is used via the `spring-security-crypto` library. This is **not** a transitive dependency of the current stack — it must be added explicitly to `pom.xml` as a standalone dependency (without pulling in full Spring Security).
+
+### HttpSession over JWT
+JWT requires a token library, signing keys, and frontend token storage logic. `HttpSession` is a single cookie managed by the browser automatically. For a local dev tool this is the right tradeoff. The session cookie (`JSESSIONID`) is HttpOnly by default.
+
+### Seed data in Liquibase
+Test users are seeded via a dedicated Liquibase changelog rather than a separate script. This means any developer with a fresh DB gets the test users automatically — no manual setup step. Note: `created_at`/`updated_at` will use the Liquibase execution time, so timestamps shift on every fresh DB setup — acceptable for dev seed data.
+
+### AuthContext in React (in-memory, session cookie)
+The frontend stores the logged-in user in React context state. On mount, the context calls `GET /api/auth/me` — if the session cookie is still valid, it hydrates the user state silently. This means the page survives a refresh without re-login. No JWT, no localStorage — just the session cookie doing the work.
+
+### Route guard at the router level
+All routes except `/login` are wrapped in a single `<RequireAuth>` component. If `currentUser` is null and loading is complete, it redirects to `/login`. This is a single change point; individual pages have no auth awareness.
+
+### PasswordVerifier port (hexagonal compliance)
+`AuthService` lives in the domain layer, which must have no Spring dependencies. Rather than importing Spring's `PasswordEncoder` into the domain, we define a `PasswordVerifier` port interface in `domain/port/` and adapt `BCryptPasswordEncoder` behind it in the adapter layer. This keeps the domain clean for a small cost.
+
+### Removing manual UUID fields
+Once `currentUser.id` is available globally, the `ownerId` / `userId` inputs in `CreateGroupPage` and `JoinGroupPage` should be replaced with the value from context. These pages are currently unmerged WIP on a feature branch — this cleanup applies when those pages are present and merged.
+
+---
+
+## Scope
+
+This plan covers:
+
+**Backend**
+- Maven dependency: add `spring-security-crypto`
+- Liquibase migration: add `password_hash` column to `users` table
+- Liquibase migration: seed 5 test users with bcrypt hashed passwords
+- `PasswordVerifier` port + `BCryptPasswordVerifier` adapter
+- `AuthService`: login (verify password) + getById
+- `AuthController`: `POST /api/auth/login`, `GET /api/auth/me`, `POST /api/auth/logout`
+- `SessionService`: thin wrapper to read/write `userId` on `HttpSession`
+- Exception classes: `InvalidCredentialsException` (401), `UserNotFoundException` (404)
+- CORS config update: `allowCredentials(true)` for session cookies
+- Wire new beans in `DomainConfig`
+- `AuthController` tests: happy path login, bad password, /me with/without session
+
+**Frontend**
+- `authApi.ts`: API client for login/me/logout
+- `AuthContext.tsx`: React context — holds `currentUser`, `login()`, `logout()`, loading state
+- `LoginPage/`: simple email + password form with test credentials displayed below
+- `RequireAuth.tsx`: route guard component
+- Update `AppRouter.tsx`: wrap existing routes with `<RequireAuth>`, add `/login` route
+- Update `MainLayout`: show current username and a logout button
+
+**Deferred (applies when group pages are merged)**
+- Update `CreateGroupPage`: remove manual `ownerId` input, use `currentUser.id`
+- Update `JoinGroupPage`: remove manual `userId` input, use `currentUser.id`
+
+**Not in scope**
+- Registration UI (users are seeded only; `POST /api/users` remains for programmatic use)
+- Role-based access control on backend endpoints
+- Google OAuth integration
+- Password reset / change
+- Any production hardening (rate limiting, CSRF, etc.)
+
+---
+
+## Backend Implementation
+
+### Step 1 — Maven dependency
+
+Add to `backend/pom.xml`:
+
+```xml
+<dependency>
+    <groupId>org.springframework.security</groupId>
+    <artifactId>spring-security-crypto</artifactId>
+</dependency>
+```
+
+This pulls in only the crypto utilities (BCrypt, etc.) without Spring Security's web/filter infrastructure. Version is managed by the Spring Boot BOM.
+
+### Step 2 — Liquibase: add password_hash column
+
+File: `backend/src/main/resources/db/changelog/006-add-password-hash-to-users.yaml`
+
+```yaml
+databaseChangeLog:
+  - changeSet:
+      id: 006-add-password-hash-to-users
+      author: dev
+      changes:
+        - addColumn:
+            tableName: users
+            columns:
+              - column:
+                  name: password_hash
+                  type: varchar(255)
+                  constraints:
+                    nullable: true   # nullable so existing/OAuth users without a password are valid
+```
+
+Nullable because future Google OAuth users will have no password — only seeded dev users need it.
+
+### Step 3 — Liquibase: seed test users
+
+File: `backend/src/main/resources/db/changelog/007-seed-test-users.yaml`
+
+Five users, covering all useful testing scenarios:
+
+| Username | Email | Password | Role | Purpose |
+|----------|-------|----------|------|---------|
+| alice | alice@test.com | password123 | ADMIN | Admin user |
+| bob | bob@test.com | password123 | USER | Group owner |
+| carol | carol@test.com | password123 | USER | Group member |
+| dave | dave@test.com | password123 | USER | Second group member (self-referential tests) |
+| eve | eve@test.com | password123 | USER | User outside groups (access control tests) |
+
+BCrypt hashes for `password123` are pre-computed and hardcoded in the migration. All UUIDs are fixed (hardcoded) so test data referencing them remains stable across DB resets.
+
+```yaml
+databaseChangeLog:
+  - changeSet:
+      id: 007-seed-test-users
+      author: dev
+      context: dev
+      changes:
+        - insert:
+            tableName: users
+            columns:
+              - column: { name: id, value: '00000000-0000-0000-0000-000000000001' }
+              - column: { name: username, value: alice }
+              - column: { name: email, value: alice@test.com }
+              - column: { name: system_role, value: ADMIN }
+              - column: { name: password_hash, value: '$2a$10$...' }  # bcrypt of password123
+              - column: { name: created_at, valueDate: 'now()' }
+              - column: { name: updated_at, valueDate: 'now()' }
+        # ... repeat for bob, carol, dave, eve
+```
+
+Include both `006` and `007` in `db.changelog-master.yaml`.
+
+### Step 4 — PasswordVerifier port + adapter
+
+The domain layer must stay free of Spring dependencies. `AuthService` needs to verify passwords, so we define a port.
+
+Port — `backend/.../domain/port/PasswordVerifier.java`:
+```java
+public interface PasswordVerifier {
+    boolean matches(String rawPassword, String encodedPassword);
+}
+```
+
+Adapter — `backend/.../adapter/persistence/adapter/BCryptPasswordVerifier.java`:
+```java
+@Component
+public class BCryptPasswordVerifier implements PasswordVerifier {
+    private final BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+
+    @Override
+    public boolean matches(String rawPassword, String encodedPassword) {
+        return encoder.matches(rawPassword, encodedPassword);
+    }
+}
+```
+
+### Step 5 — Exception classes
+
+File: `backend/.../domain/exception/InvalidCredentialsException.java`
+```java
+public class InvalidCredentialsException extends RuntimeException {
+    public InvalidCredentialsException() {
+        super("Invalid credentials");
+    }
+}
+```
+
+File: `backend/.../domain/exception/UserNotFoundException.java`
+```java
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(UUID id) {
+        super("User not found: " + id);
+    }
+}
+```
+
+These are mapped to HTTP status codes in the controller layer via `@ExceptionHandler` or a `@RestControllerAdvice` class that returns 401 for `InvalidCredentialsException` and 404 for `UserNotFoundException`.
+
+File: `backend/.../adapter/rest/AuthExceptionHandler.java`
+```java
+@RestControllerAdvice
+public class AuthExceptionHandler {
+    @ExceptionHandler(InvalidCredentialsException.class)
+    public ResponseEntity<Void> handleInvalidCredentials(InvalidCredentialsException ex) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<Void> handleUserNotFound(UserNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+    }
+}
+```
+
+### Step 6 — SessionService
+
+File: `backend/.../adapter/rest/SessionService.java`
+
+```java
+@Component
+public class SessionService {
+    private static final String USER_ID_KEY = "userId";
+
+    public void setUserId(HttpSession session, UUID userId) {
+        session.setAttribute(USER_ID_KEY, userId);
+    }
+
+    public Optional<UUID> getUserId(HttpSession session) {
+        return Optional.ofNullable((UUID) session.getAttribute(USER_ID_KEY));
+    }
+
+    public void invalidate(HttpSession session) {
+        session.invalidate();
+    }
+}
+```
+
+This is infrastructure (depends on `jakarta.servlet.http.HttpSession`), so it lives in the adapter layer at `adapter/rest/`, not in `domain/service/`.
+
+### Step 7 — AuthService
+
+File: `backend/.../domain/service/AuthService.java`
+
+```java
+public class AuthService {
+    private final UserRepositoryPort userRepository;
+    private final PasswordVerifier passwordVerifier;
+
+    public User login(String email, String password) {
+        User user = userRepository.findByEmail(email)
+            .orElseThrow(InvalidCredentialsException::new);
+        if (!passwordVerifier.matches(password, user.getPasswordHash())) {
+            throw new InvalidCredentialsException();
+        }
+        return user;
+    }
+
+    public User getById(UUID id) {
+        return userRepository.findById(id)
+            .orElseThrow(() -> new UserNotFoundException(id));
+    }
+}
+```
+
+Uses the `PasswordVerifier` port — no Spring imports in the domain layer. The error message is deliberately vague ("Invalid credentials") for both bad email and bad password.
+
+### Step 8 — AuthController
+
+File: `backend/.../adapter/rest/controller/AuthController.java`
+
+Three endpoints:
+
+**POST /api/auth/login**
+```
+Request:  { "email": "alice@test.com", "password": "password123" }
+Response: { "id": "...", "username": "alice", "email": "alice@test.com", "systemRole": "ADMIN" }
+```
+Calls `AuthService.login()`. On success, stores `userId` in session via `SessionService`. Returns `UserResponse`.
+
+**GET /api/auth/me**
+```
+Response: { "id": "...", "username": "alice", "email": "alice@test.com", "systemRole": "ADMIN" }
+         or 401 if no session
+```
+Reads `userId` from session, looks up user via `AuthService.getById()`. Returns `UserResponse` or 401.
+
+**POST /api/auth/logout**
+```
+Response: 204 No Content
+```
+Calls `SessionService.invalidate()`.
+
+DTO — `backend/.../adapter/rest/dto/LoginRequest.java`:
+```java
+public record LoginRequest(String email, String password) {}
+```
+
+### Step 9 — CORS config update
+
+Update `CorsConfig.java` to allow credentials — required for session cookies to be sent cross-origin (relevant when running frontend and backend on different ports without the Vite proxy, e.g. Docker with nginx):
+
+```java
+configuration.setAllowCredentials(true);
+```
+
+Note: `allowCredentials(true)` cannot be combined with `allowedOrigins("*")` — must use explicit origins. The current config already reads from `ALLOWED_ORIGIN` env var with a default, so this should work.
+
+### Step 10 — Wire in DomainConfig
+
+Add `AuthService` bean to `DomainConfig.java`:
+
+```java
+@Bean
+public AuthService authService(UserRepositoryPort userRepository, PasswordVerifier passwordVerifier) {
+    return new AuthService(userRepository, passwordVerifier);
+}
+```
+
+`BCryptPasswordVerifier` is `@Component`-scanned automatically — no explicit bean needed.
+
+### Step 11 — Update User domain entity and persistence layer
+
+- Add `passwordHash` field (String, nullable) to `User.java` domain entity
+- Add `passwordHash` column to `UserEntity.java` JPA entity
+- Update `UserMapper.java` to map `passwordHash` in both `toDomain` and `toEntity`
+- `UserRepositoryPort.findByEmail()` already exists — no change needed
+
+### Step 12 — Tests
+
+File: `backend/.../adapter/rest/controller/AuthControllerTest.java`
+
+Minimum test cases:
+- `POST /api/auth/login` with valid credentials returns 200 + user JSON
+- `POST /api/auth/login` with wrong password returns 401
+- `POST /api/auth/login` with nonexistent email returns 401
+- `GET /api/auth/me` with valid session returns 200 + user JSON
+- `GET /api/auth/me` without session returns 401
+- `POST /api/auth/logout` invalidates session
+
+---
+
+## Frontend Implementation
+
+### Step 1 — authApi.ts
+
+File: `frontend/src/services/authApi.ts`
+
+```typescript
+const BASE = '/api/auth';
+
+export interface CurrentUser {
+  id: string;
+  username: string;
+  email: string;
+  systemRole: 'ADMIN' | 'USER';
+}
+
+export const authApi = {
+  login: (email: string, password: string): Promise<CurrentUser> =>
+    fetch(`${BASE}/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    }).then(res => {
+      if (!res.ok) throw new Error('Invalid credentials');
+      return res.json();
+    }),
+
+  me: (): Promise<CurrentUser | null> =>
+    fetch(`${BASE}/me`).then(res =>
+      res.ok ? res.json() : null
+    ),
+
+  logout: (): Promise<void> =>
+    fetch(`${BASE}/logout`, { method: 'POST' }).then(() => {}),
+};
+```
+
+Note on `credentials`: In local dev, Vite proxies `/api` to `localhost:8080` making it same-origin — `credentials: 'include'` is not needed. If running cross-origin (Docker/nginx), add `credentials: 'include'` to all calls and ensure the CORS config has `allowCredentials(true)` (see backend step 9).
+
+### Step 2 — AuthContext.tsx
+
+File: `frontend/src/context/AuthContext.tsx`
+
+```typescript
+interface AuthContextValue {
+  currentUser: CurrentUser | null;
+  loading: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+}
+```
+
+On mount, calls `authApi.me()` to restore session. `loading` is `true` until this resolves — prevents a flash-redirect to `/login` on page refresh when the session is valid.
+
+Wrap in `main.tsx`: `<AuthProvider>` goes inside `<BrowserRouter>` (since login redirect uses `useNavigate`).
+
+### Step 3 — RequireAuth.tsx
+
+File: `frontend/src/components/auth/RequireAuth.tsx`
+
+```typescript
+export function RequireAuth({ children }: { children: ReactNode }) {
+  const { currentUser, loading } = useAuth();
+  if (loading) return null; // or a spinner
+  if (!currentUser) return <Navigate to="/login" replace />;
+  return <>{children}</>;
+}
+```
+
+### Step 4 — LoginPage
+
+File: `frontend/src/pages/LoginPage/LoginPage.tsx`
+
+Simple form with email + password inputs. On submit calls `login()` from `useAuth()`, then navigates to `/`. Shows an error message on 401. No registration link — accounts are seeded only.
+
+**Dev convenience:** Display the test credentials table below the form so developers don't need to look them up elsewhere.
+
+### Step 5 — AppRouter.tsx
+
+Add `/login` to `routePaths.ts` and update `AppRouter.tsx`:
+
+```typescript
+<Routes>
+  <Route path={ROUTE_PATHS.login} element={<LoginPage />} />
+  <Route element={<RequireAuth><MainLayout /></RequireAuth>}>
+    <Route path={ROUTE_PATHS.home} element={<HomePage />} />
+    <Route path={ROUTE_PATHS.predictions} element={<PredictionsPage />} />
+    <Route path={ROUTE_PATHS.tournaments} element={<TournamentPage />} />
+  </Route>
+</Routes>
+```
+
+### Step 6 — MainLayout
+
+Add to the header: username display and a logout button that calls `logout()` from `useAuth()` and navigates to `/login`.
+
+---
+
+## File Checklist
+
+### New files
+- `backend/.../db/changelog/006-add-password-hash-to-users.yaml`
+- `backend/.../db/changelog/007-seed-test-users.yaml`
+- `backend/.../domain/port/PasswordVerifier.java`
+- `backend/.../adapter/persistence/adapter/BCryptPasswordVerifier.java`
+- `backend/.../domain/exception/InvalidCredentialsException.java`
+- `backend/.../domain/exception/UserNotFoundException.java`
+- `backend/.../adapter/rest/AuthExceptionHandler.java`
+- `backend/.../adapter/rest/SessionService.java`
+- `backend/.../domain/service/AuthService.java`
+- `backend/.../adapter/rest/controller/AuthController.java`
+- `backend/.../adapter/rest/dto/LoginRequest.java`
+- `backend/.../adapter/rest/controller/AuthControllerTest.java`
+- `frontend/src/services/authApi.ts`
+- `frontend/src/context/AuthContext.tsx`
+- `frontend/src/components/auth/RequireAuth.tsx`
+- `frontend/src/pages/LoginPage/LoginPage.tsx`
+
+### Modified files
+- `backend/pom.xml` — add `spring-security-crypto` dependency
+- `backend/.../db/changelog/db.changelog-master.yaml` — include 006, 007
+- `backend/.../domain/entity/User.java` — add `passwordHash` field
+- `backend/.../adapter/persistence/entity/UserEntity.java` — add `passwordHash` column
+- `backend/.../adapter/persistence/mapper/UserMapper.java` — map passwordHash
+- `backend/.../config/DomainConfig.java` — wire AuthService bean
+- `backend/.../config/CorsConfig.java` — add allowCredentials(true)
+- `frontend/src/main.tsx` — wrap with `<AuthProvider>`
+- `frontend/src/app/routePaths.ts` — add `login` path
+- `frontend/src/app/router/AppRouter.tsx` — add login route + RequireAuth wrapper
+- `frontend/src/components/layout/MainLayout.tsx` — add user display + logout
+
+### Deferred (when group pages are merged)
+- `frontend/src/pages/CreateGroupPage/CreateGroupPage.tsx` — remove ownerId input
+- `frontend/src/pages/JoinGroupPage/JoinGroupPage.tsx` — remove userId input
+
+---
+
+## Test Credentials
+
+| Email | Password | Role | UUID |
+|-------|----------|------|------|
+| alice@test.com | password123 | ADMIN | 00000000-0000-0000-0000-000000000001 |
+| bob@test.com | password123 | USER | 00000000-0000-0000-0000-000000000002 |
+| carol@test.com | password123 | USER | 00000000-0000-0000-0000-000000000003 |
+| dave@test.com | password123 | USER | 00000000-0000-0000-0000-000000000004 |
+| eve@test.com | password123 | USER | 00000000-0000-0000-0000-000000000005 |
+
+---
+
+## Migration Path to Google OAuth
+
+When Google OAuth is added:
+1. Add `google_id` column to users table
+2. Add a new login flow that upserts a user by `google_id` and calls `SessionService.setUserId()`
+3. `AuthController`, `AuthService`, `SessionService` remain unchanged
+4. Seeded dev users continue to work via the password login endpoint
+5. Eventually the password login endpoint can be disabled in production via a feature flag or Spring profile
+
+The session-based approach means the frontend has zero changes when the auth backend changes — `GET /api/auth/me` always returns the same shape.

--- a/frontend/src/app/routePaths.ts
+++ b/frontend/src/app/routePaths.ts
@@ -2,4 +2,5 @@ export const ROUTE_PATHS = {
   home: '/',
   predictions: '/predictions',
   tournaments: '/tournaments',
+  login: '/login',
 } as const;

--- a/frontend/src/app/router/AppRouter.tsx
+++ b/frontend/src/app/router/AppRouter.tsx
@@ -1,7 +1,9 @@
 import { Route, Routes } from 'react-router-dom';
 
+import { RequireAuth } from '../../components/auth/RequireAuth';
 import { MainLayout } from '../../components/layout/MainLayout';
 import HomePage from '../../pages/HomePage/HomePage';
+import LoginPage from '../../pages/LoginPage/LoginPage';
 import PredictionsPage from '../../pages/PredictionsPage/PredictionsPage';
 import TournamentPage from '../../pages/TournamentPage/TournamentPage';
 import { ROUTE_PATHS } from '../routePaths';
@@ -9,7 +11,14 @@ import { ROUTE_PATHS } from '../routePaths';
 export function AppRouter() {
   return (
     <Routes>
-      <Route element={<MainLayout />}>
+      <Route path={ROUTE_PATHS.login} element={<LoginPage />} />
+      <Route
+        element={
+          <RequireAuth>
+            <MainLayout />
+          </RequireAuth>
+        }
+      >
         <Route path={ROUTE_PATHS.home} element={<HomePage />} />
         <Route path={ROUTE_PATHS.predictions} element={<PredictionsPage />} />
         <Route path={ROUTE_PATHS.tournaments} element={<TournamentPage />} />

--- a/frontend/src/components/auth/RequireAuth.tsx
+++ b/frontend/src/components/auth/RequireAuth.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../../context/AuthContext';
+
+export function RequireAuth({ children }: { children: ReactNode }) {
+  const { currentUser, loading } = useAuth();
+  if (loading) return null;
+  if (!currentUser) return <Navigate to="/login" replace />;
+  return <>{children}</>;
+}

--- a/frontend/src/components/auth/RequireAuth.tsx
+++ b/frontend/src/components/auth/RequireAuth.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { Navigate } from 'react-router-dom';
-import { useAuth } from '../../context/AuthContext';
+
+import { useAuth } from '../../context/useAuth';
 
 export function RequireAuth({ children }: { children: ReactNode }) {
   const { currentUser, loading } = useAuth();

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -1,7 +1,7 @@
 import { NavLink, Outlet, useNavigate } from 'react-router-dom';
 
 import { ROUTE_PATHS } from '../../app/routePaths';
-import { useAuth } from '../../context/AuthContext';
+import { useAuth } from '../../context/useAuth';
 
 export function MainLayout() {
   const { currentUser, logout } = useAuth();

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -1,8 +1,17 @@
-import { NavLink, Outlet } from 'react-router-dom';
+import { NavLink, Outlet, useNavigate } from 'react-router-dom';
 
 import { ROUTE_PATHS } from '../../app/routePaths';
+import { useAuth } from '../../context/AuthContext';
 
 export function MainLayout() {
+  const { currentUser, logout } = useAuth();
+  const navigate = useNavigate();
+
+  async function handleLogout() {
+    await logout();
+    navigate(ROUTE_PATHS.login);
+  }
+
   return (
     <div>
       <header>
@@ -37,8 +46,17 @@ export function MainLayout() {
             >
               Tournaments
             </NavLink>
-          
           </nav>
+
+          <div className="flex items-center gap-3">
+            <span className="text-sm text-gray-600">{currentUser?.username}</span>
+            <button
+              onClick={handleLogout}
+              className="rounded border border-gray-300 px-3 py-1 text-sm hover:bg-gray-100"
+            >
+              Sign out
+            </button>
+          </div>
         </div>
       </header>
 

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,47 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
+import { authApi } from '../services/authApi';
+import type { CurrentUser } from '../services/authApi';
+
+interface AuthContextValue {
+  currentUser: CurrentUser | null;
+  loading: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [currentUser, setCurrentUser] = useState<CurrentUser | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    authApi.me().then(user => {
+      setCurrentUser(user);
+      setLoading(false);
+    });
+  }, []);
+
+  async function login(email: string, password: string) {
+    const user = await authApi.login(email, password);
+    setCurrentUser(user);
+  }
+
+  async function logout() {
+    await authApi.logout();
+    setCurrentUser(null);
+  }
+
+  return (
+    <AuthContext.Provider value={{ currentUser, loading, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used inside AuthProvider');
+  return ctx;
+}

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,16 +1,9 @@
-import { createContext, useContext, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
+
+import { AuthContext } from './authContextDef';
 import { authApi } from '../services/authApi';
 import type { CurrentUser } from '../services/authApi';
-
-interface AuthContextValue {
-  currentUser: CurrentUser | null;
-  loading: boolean;
-  login: (email: string, password: string) => Promise<void>;
-  logout: () => Promise<void>;
-}
-
-const AuthContext = createContext<AuthContextValue | null>(null);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [currentUser, setCurrentUser] = useState<CurrentUser | null>(null);
@@ -38,10 +31,4 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       {children}
     </AuthContext.Provider>
   );
-}
-
-export function useAuth(): AuthContextValue {
-  const ctx = useContext(AuthContext);
-  if (!ctx) throw new Error('useAuth must be used inside AuthProvider');
-  return ctx;
 }

--- a/frontend/src/context/authContextDef.ts
+++ b/frontend/src/context/authContextDef.ts
@@ -1,0 +1,12 @@
+import { createContext } from 'react';
+
+import type { CurrentUser } from '../services/authApi';
+
+export interface AuthContextValue {
+  currentUser: CurrentUser | null;
+  loading: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+}
+
+export const AuthContext = createContext<AuthContextValue | null>(null);

--- a/frontend/src/context/useAuth.ts
+++ b/frontend/src/context/useAuth.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+
+import { AuthContext } from './authContextDef';
+import type { AuthContextValue } from './authContextDef';
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used inside AuthProvider');
+  return ctx;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,12 +3,15 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 
 import App from './App';
+import { AuthProvider } from './context/AuthContext';
 import './styles/index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/frontend/src/pages/LoginPage/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage/LoginPage.tsx
@@ -1,0 +1,116 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../context/AuthContext';
+import { ROUTE_PATHS } from '../../app/routePaths';
+
+const TEST_USERS = [
+  { email: 'alice@test.com', password: '***', role: 'ADMIN' },
+  { email: 'bob@test.com', password: '***', role: 'USER' },
+  { email: 'carol@test.com', password: '***', role: 'USER' },
+  { email: 'dave@test.com', password: '***', role: 'USER' },
+]
+
+export default function LoginPage() {
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+    try {
+      await login(email, password);
+      navigate(ROUTE_PATHS.home);
+    } catch {
+      setError('Invalid email or password.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function fillUser(userEmail: string) {
+    setEmail(userEmail);
+    setPassword('predictorama123');
+    setError('');
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
+      <div className="w-full max-w-sm">
+        <h1 className="mb-6 text-center text-2xl font-semibold">Predict-o-rama</h1>
+
+        <form onSubmit={handleSubmit} className="mb-6 space-y-4">
+          <div>
+            <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="email">
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              required
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div>
+            <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="password">
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              required
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          {error && <p className="text-sm text-red-600">{error}</p>}
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {loading ? 'Signing in…' : 'Sign in'}
+          </button>
+        </form>
+
+        <div className="rounded border border-gray-200 bg-white p-4">
+          <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+            Dev accounts — click to fill
+          </p>
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="text-left text-gray-400">
+                <th className="pb-1 pr-2">Email</th>
+                <th className="pb-1 pr-2">Password</th>
+                <th className="pb-1">Role</th>
+              </tr>
+            </thead>
+            <tbody>
+              {TEST_USERS.map(u => (
+                <tr
+                  key={u.email}
+                  className="cursor-pointer hover:bg-gray-50"
+                  onClick={() => fillUser(u.email)}
+                >
+                  <td className="py-0.5 pr-2 text-blue-600">{u.email}</td>
+                  <td className="py-0.5 pr-2 text-gray-500">{u.password}</td>
+                  <td className="py-0.5 text-gray-500">{u.role}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/LoginPage/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage/LoginPage.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useAuth } from '../../context/AuthContext';
+
 import { ROUTE_PATHS } from '../../app/routePaths';
+import { useAuth } from '../../context/useAuth';
 
 const TEST_USERS = [
   { email: 'alice@test.com', password: '***', role: 'ADMIN' },

--- a/frontend/src/services/authApi.ts
+++ b/frontend/src/services/authApi.ts
@@ -1,0 +1,26 @@
+const BASE = '/api/auth';
+
+export interface CurrentUser {
+  id: string;
+  username: string;
+  email: string;
+  systemRole: 'ADMIN' | 'USER';
+}
+
+export const authApi = {
+  login: (email: string, password: string): Promise<CurrentUser> =>
+    fetch(`${BASE}/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    }).then(res => {
+      if (!res.ok) throw new Error('Invalid credentials');
+      return res.json();
+    }),
+
+  me: (): Promise<CurrentUser | null> =>
+    fetch(`${BASE}/me`).then(res => (res.ok ? res.json() : null)),
+
+  logout: (): Promise<void> =>
+    fetch(`${BASE}/logout`, { method: 'POST' }).then(() => {}),
+};


### PR DESCRIPTION
The app currently has no authentication. Every page that requires a user assumes a logged-in session, and workarounds like manually pasting UUIDs into form fields are in place. This makes UI development and multi-user testing extremely painful.

The long-term plan is Google OAuth, but that is not yet done. This plan implements a **temporary, dev-grade login system** using email + bcrypt password. It is intentionally minimal — no Spring Security, no JWT, no token refresh — just enough to:

- Allow real login with multiple named test users
- Provide a `currentUser` (with a real UUID) to every frontend page
- Remove all manual UUID input workarounds
- Support different roles and user scenarios (e.g. self-referential checks, group ownership)

This solution will coexist with Google OAuth when that is added; the `users` table already exists and the password column can simply remain unused for OAuth users.

Add dummy users and shortcut login for these.
<img width="1090" height="1156" alt="image" src="https://github.com/user-attachments/assets/82e2e4b2-c93b-4a10-a170-cc1c2c712595" />
<img width="1424" height="530" alt="image" src="https://github.com/user-attachments/assets/4ff6505c-6fd3-4188-9f32-0ff95b55ccc8" />
