### PR TITLE
Merge deploy failed

### DIFF
--- a/frontend/src/app/routePaths.ts
+++ b/frontend/src/app/routePaths.ts
@@ -1,6 +1,7 @@
 export const ROUTE_PATHS = {
   home: '/',
   predictions: '/predictions',
+  tournaments: '/tournaments',
   login: '/login',
   groups: '/groups',
   groupDetails: '/groups/:groupId',


### PR DESCRIPTION
 tournaments: '/tournaments' was dropped during the merge.